### PR TITLE
Undo config changes

### DIFF
--- a/packages/layer-climb-config/src/config.rs
+++ b/packages/layer-climb-config/src/config.rs
@@ -10,18 +10,6 @@ pub struct ChainConfig {
     pub gas_amount: String,
     pub gas_denom: String,
     pub address_kind: AddrKind,
-    pub wasmatic: WasmaticConfig,
-    pub faucet: FaucetConfig,
-}
-
-#[derive(Debug, Deserialize, Serialize, Clone)]
-pub struct WasmaticConfig {
-    pub endpoint: String,
-}
-
-#[derive(Debug, Deserialize, Serialize, Clone)]
-pub struct FaucetConfig {
-    pub mnemonic: String,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]


### PR DESCRIPTION
This reverts part of PR #19 that modified the struct.
It kept the refactoring of how the addresses were resolved.